### PR TITLE
bugfix: add missing: ipv6 accept_ra = 0

### DIFF
--- a/default/serverspec/sysctl_spec.rb
+++ b/default/serverspec/sysctl_spec.rb
@@ -167,6 +167,14 @@ describe 'NSA 2.5.3.2.5 Limit Network-Transmitted Configuration' do
     its(:value) { should eq 0 }
   end
 
+  context linux_kernel_parameter('net.ipv6.conf.all.accept_ra') do
+    its(:value) { should eq 0 }
+  end
+
+  context linux_kernel_parameter('net.ipv6.conf.default.accept_ra') do
+    its(:value) { should eq 0 }
+  end
+
   context linux_kernel_parameter('net.ipv6.conf.default.autoconf') do
     its(:value) { should eq 0 }
   end


### PR DESCRIPTION
This was uncovered by @igoraj at https://github.com/hardening-io/puppet-os-hardening/issues/56 .
Thank you for your help :)